### PR TITLE
APM-970 Allow access to base paths from internal testing product

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -62,7 +62,7 @@ resource "apigee_product" "internal_testing" {
   display_name = "internal-testing (${var.apigee_environment})"
   description = "For internal testing purposes only. Customers should NOT be subscribed to this product."
   approval_type = "manual"
-  api_resources = ["/**"]                 # Allows access to everything...
+  api_resources = ["/", "/**", "/*/"]     # Allows access to everything...
   environments = [var.apigee_environment] # ...in this environment
 
   quota = 60000 # 1000ps


### PR DESCRIPTION
## Summary
* :robot: Allow access to base paths, e.g. `proxyname/` and not just `proxyname/somepath` with the `internal-testing-<env>` products.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
